### PR TITLE
Upgrade to Lean 4.8.0 and add lean_initialize_thread and lean_finalize_thread

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lean-sys"
-version = "0.0.6"
+version = "0.0.7"
 authors = [
     "Jad Ghalayini <jeg74@cl.cam.ac.uk>",
     "Mario Carneiro <mcarneir@andrew.cmu.edu>",

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.6.0
+leanprover/lean4:v4.8.0

--- a/src/int.rs
+++ b/src/int.rs
@@ -133,6 +133,76 @@ pub unsafe fn lean_int_mod(a1: b_lean_obj_arg, a2: b_lean_obj_arg) -> lean_obj_r
     }
 }
 
+pub unsafe fn lean_int_ediv(a1: b_lean_obj_arg, a2: b_lean_obj_arg) -> lean_obj_res {
+    if lean_is_scalar(a1) && lean_is_scalar(a2) {
+        if core::mem::size_of::<usize>() == 8 {
+            /* 64-bit version, we use 64-bit numbers to avoid overflow when v1 == LEAN_MIN_SMALL_INT. */
+            let n = lean_scalar_to_int64(a1);
+            let d = lean_scalar_to_int64(a2);
+            if d == 0 {
+                lean_box(0)
+            } else {
+                let mut q = n / d;
+                let r = n % d;
+                if r < 0 {
+                    q = if d > 0 { q - 1 } else { q + 1 };
+                }
+                lean_int64_to_int(q)
+            }
+        } else {
+            /* 32-bit version */
+            let n = lean_scalar_to_int(a1);
+            let d = lean_scalar_to_int(a2);
+            if d == 0 {
+                lean_box(0)
+            } else {
+                let mut q = n / d;
+                let r = n % d;
+                if r < 0 {
+                    q = if d > 0 { q - 1 } else { q + 1 };
+                }
+                lean_int_to_int(q)
+            }
+        }
+    } else {
+        lean_int_big_ediv(a1, a2)
+    }
+}
+
+pub unsafe fn lean_int_emod(a1: b_lean_obj_arg, a2: b_lean_obj_arg) -> lean_obj_res {
+    if lean_is_scalar(a1) && lean_is_scalar(a2) {
+        if core::mem::size_of::<usize>() == 8 {
+            /* 64-bit version, we use 64-bit numbers to avoid overflow when v1 == LEAN_MIN_SMALL_INT. */
+            let n = lean_scalar_to_int64(a1);
+            let d = lean_scalar_to_int64(a2);
+            if d == 0 {
+                a1
+            } else {
+                let mut r = n % d;
+                if r < 0 {
+                    r = if d > 0 { r + d } else { r - d };
+                }
+                lean_int64_to_int(r)
+            }
+        } else {
+            /* 32-bit version */
+            let n = lean_scalar_to_int(a1);
+            let d = lean_scalar_to_int(a2);
+            if d == 0 {
+                a1
+            } else {
+                let mut r = n % d;
+                if r < 0 {
+                    r = if d > 0 { r + d } else { r - d };
+                }
+                lean_int_to_int(r)
+            }
+        }
+    } else {
+        lean_int_big_emod(a1, a2)
+    }
+}
+
 #[inline]
 pub unsafe fn lean_int_eq(a1: b_lean_obj_arg, a2: b_lean_obj_arg) -> bool {
     a1 == a2 || lean_int_big_eq(a1, a2)
@@ -213,6 +283,8 @@ extern "C" {
     pub fn lean_int_big_mul(a1: *mut lean_object, a2: *mut lean_object) -> *mut lean_object;
     pub fn lean_int_big_div(a1: *mut lean_object, a2: *mut lean_object) -> *mut lean_object;
     pub fn lean_int_big_mod(a1: *mut lean_object, a2: *mut lean_object) -> *mut lean_object;
+    pub fn lean_int_big_ediv(a1: *mut lean_object, a2: *mut lean_object) -> *mut lean_object;
+    pub fn lean_int_big_emod(a1: *mut lean_object, a2: *mut lean_object) -> *mut lean_object;
     pub fn lean_int_big_eq(a1: *mut lean_object, a2: *mut lean_object) -> bool;
     pub fn lean_int_big_le(a1: *mut lean_object, a2: *mut lean_object) -> bool;
     pub fn lean_int_big_lt(a1: *mut lean_object, a2: *mut lean_object) -> bool;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ pub mod primitive;
 pub mod sarray;
 pub mod string;
 pub mod task;
+pub mod thread;
 pub mod thunk;
 
 pub use array::*;
@@ -44,6 +45,7 @@ pub use primitive::*;
 pub use sarray::*;
 pub use string::*;
 pub use task::*;
+pub use thread::*;
 pub use thunk::*;
 
 pub const LEAN_SMALL_ALLOCATOR: bool = cfg!(feature = "small_allocator");

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -13,6 +13,7 @@ use crate::{
 /// }
 /// ```
 pub fn panic_handler(info: &core::panic::PanicInfo) -> ! {
+    #[allow(deprecated)] // the payload() function always returns None
     let message = if let Some(s) = info.payload().downcast_ref::<&str>() {
         s.as_bytes()
     } else {

--- a/src/string.rs
+++ b/src/string.rs
@@ -134,4 +134,5 @@ extern "C" {
     pub fn lean_string_eq_cold(s1: b_lean_obj_arg, s2: b_lean_obj_arg) -> bool;
     pub fn lean_string_lt(s1: b_lean_obj_arg, s2: b_lean_obj_arg) -> bool;
     pub fn lean_string_hash(s: b_lean_obj_arg) -> u64;
+    pub fn lean_string_of_usize(s: usize) -> lean_obj_res;
 }

--- a/src/task.rs
+++ b/src/task.rs
@@ -64,8 +64,8 @@ extern "C" {
     pub fn lean_io_check_canceled_core() -> bool;
     /** primitive for implementing `IO.cancel : Task a -> IO Unit` */
     pub fn lean_io_cancel_core(t: b_lean_obj_arg);
-    /** primitive for implementing `IO.hasFinished : Task a -> IO Unit` */
-    pub fn lean_io_has_finished_core(t: b_lean_obj_arg) -> bool;
+    /** primitive for implementing `IO.getTaskState : Task a -> IO TaskState` */
+    pub fn lean_io_get_task_state_core(t: b_lean_obj_arg) -> u8;
     /** primitive for implementing `IO.waitAny : List (Task a) -> IO (Task a)` */
     pub fn lean_io_wait_any_core(task_list: b_lean_obj_arg) -> b_lean_obj_res;
 }

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -1,0 +1,8 @@
+/*!
+Utilities for initializing Lean threads
+*/
+
+extern "C" {
+    pub fn lean_initialize_thread();
+    pub fn lean_finalize_thread();
+}


### PR DESCRIPTION
Upgrade to Lean 4.8.0 and add `lean_initialize_thread` and `lean_finalize_thread`.

Lean added these functions to support multiple FFI threads in this PR: https://github.com/leanprover/lean4/commit/3921257ecef826177cf55ca1082ff76f100b10ca which was released in Lean 4.8.0.
