### PR TITLE
Fix a linking issue on macOS

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -24,8 +24,7 @@ jobs:
           echo "$HOME/.elan/bin" >> $GITHUB_PATH
       - name: Initialize Rustup
         run: |
-          rustup toolchain install nightly --component rustfmt,clippy --profile minimal --force
-          rustup override set nightly
+          rustup toolchain install --component rustfmt,clippy --profile minimal --force
       - name: Run build
         run: cargo build --verbose
       - name: Build Release

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -8,7 +8,13 @@ env:
   CARGO_TERM_COLOR: always
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - runs-on: ubuntu-latest
+          - runs-on: ubuntu-24.04-arm
+          - runs-on: macos-latest
+    runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v3
       - name: Initialize Lean

--- a/build.rs
+++ b/build.rs
@@ -73,8 +73,13 @@ fn main() {
             }
             println!("cargo:rustc-link-arg=-Wl,--end-group");
         }
-        for lib in ["Lake", "c++", "c++abi"] {
-            println!("cargo:rustc-link-lib=static={lib}");
+        println!("cargo:rustc-link-lib=static=Lake");
+        for lib in ["c++", "c++abi"] {
+            if cfg!(target_os = "macos") {
+                println!("cargo:rustc-link-lib=dylib={lib}");
+            } else {
+                println!("cargo:rustc-link-lib=static={lib}");
+            }
         }
         for lib in ["m", "dl", "gmp"] {
             println!("cargo:rustc-link-lib=dylib={lib}");

--- a/src/string.rs
+++ b/src/string.rs
@@ -24,6 +24,7 @@ pub unsafe fn lean_string_byte_size(o: *mut lean_object) -> usize {
 
 /** instance : inhabited char := ⟨'A'⟩ */
 #[inline(always)]
+#[allow(clippy::char_lit_as_u8)]
 pub fn lean_char_default_value() -> c_char {
     'A' as c_char
 }


### PR DESCRIPTION
macOS doesn't seem to ship a static version of libc++/libc++abi, so this PR marks them dynamic if the system is macOS.

I also made a few additional tweaks to the CI:
- Additional CI pipelines for building on macOS and Ubuntu ARM
- Removed Rust's nightly toolchain flag since that doesn't seem to be needed?
- Fixed a clippy error on ARM

But let me know if I should revert any of those

Thanks!